### PR TITLE
Add option to set remote PHP path

### DIFF
--- a/src/Configuration/DefaultConfiguration.php
+++ b/src/Configuration/DefaultConfiguration.php
@@ -30,6 +30,7 @@ final class DefaultConfiguration extends AbstractConfiguration
     private $keepReleases = 5;
     private $repositoryUrl;
     private $repositoryBranch = 'master';
+    private $remotePhpBinaryPath = 'php';
     private $updateRemoteComposerBinary = false;
     private $remoteComposerBinaryPath = '/usr/local/bin/composer';
     private $composerInstallFlags = '--no-dev --prefer-dist --no-interaction --quiet';
@@ -119,6 +120,13 @@ final class DefaultConfiguration extends AbstractConfiguration
     public function repositoryBranch(string $branchName) : self
     {
         $this->repositoryBranch = $branchName;
+
+        return $this;
+    }
+
+    public function remotePhpBinaryPath(string $path) : self
+    {
+        $this->remotePhpBinaryPath = $path;
 
         return $this;
     }

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -38,6 +38,7 @@ final class Option
     const permissionMode = 'permissionMode';
     const permissionUser = 'permissionUser';
     const permissionGroup = 'permissionGroup';
+    const remotePhpBinaryPath = 'remotePhpBinaryPath';
     const remoteComposerBinaryPath = 'remoteComposerBinaryPath';
     const repositoryBranch = 'repositoryBranch';
     const repositoryUrl = 'repositoryUrl';

--- a/src/Deployer/DefaultDeployer.php
+++ b/src/Deployer/DefaultDeployer.php
@@ -205,7 +205,7 @@ abstract class DefaultDeployer extends AbstractDeployer
         $server->set(Property::web_dir, sprintf('%s/%s', $remoteProjectDir, $this->getConfig(Option::webDir)));
 
         // this is needed because some projects use a binary directory different than the default one of their Symfony version
-        $server->set(Property::console_bin, sprintf('php %s/console', $this->getConfig(Option::binDir) ? $server->get(Property::bin_dir) : $this->findConsoleBinaryPath($server)));
+        $server->set(Property::console_bin, sprintf('%s %s/console', $this->getConfig(Option::remotePhpBinaryPath), $this->getConfig(Option::binDir) ? $server->get(Property::bin_dir) : $this->findConsoleBinaryPath($server)));
     }
 
     // this is needed because it's common for Smyfony projects to use binary directories


### PR DESCRIPTION
There are some server configurations/services that have multiple PHP versions installed and, therefore, the default `php` binary may not point to the required version for the project.

I added a new option to that allows to set the remote PHP binary path in deployer configuration:

```php
public function configure()
{
    return $this->getConfigBuilder()
        ->remotePhpBinaryPath('/usr/bin/php7.1')
        // ...
    ;
}
```

Then, all console commands are prepended by the php path:

```
/usr/bin/php7.1-sp /path/to/project/releases/20170528000748/bin/console
```

The default path, in case it is not set, is `php`, as it was set originally.