### PR TITLE
Separate sharedFiles and sharedDirs.

### DIFF
--- a/doc/default-deployer.md
+++ b/doc/default-deployer.md
@@ -162,9 +162,11 @@ The values must be paths relative to the project root dir (which is usually
 `kernel.root_dir/../`). Its default value depends on the Symfony version used by
 your application:
 
-  * `->sharedFilesAndDirs(array $paths = ['...'])` (by default,
-    `app/config/parameters.yml` file in Symfony 2 and 3 and no file in Symfony 4;
-    and the `app/logs/` dir in Symfony 2 and `var/logs/` in Symfony 3 and 4)
+  * `->sharedFiles(array $paths = ['...'])` (by default,
+    `app/config/parameters.yml` file in Symfony 2 and 3 and no file in Symfony 4
+
+  * `->sharedDirs(array $paths = ['...'])` (by default,
+    `app/logs/` dir in Symfony 2 and `var/logs/` in Symfony 3 and 4)
 
 These options enable/disable some operations commonly executed after the
 application is installed:

--- a/src/Configuration/DefaultConfiguration.php
+++ b/src/Configuration/DefaultConfiguration.php
@@ -326,19 +326,38 @@ final class DefaultConfiguration extends AbstractConfiguration
     }
 
     // Relative to the project root directory
+    public function sharedFiles(array $paths) : self
+    {
+        $this->sharedFiles = $paths;
+
+        return $this;
+    }
+
+    // Relative to the project root directory
+    public function sharedDirs(array $paths) : self
+    {
+        $this->sharedDirs = $paths;
+
+        return $this;
+    }
+
+    // Relative to the project root directory
     public function sharedFilesAndDirs(array $paths) : self
     {
-        $this->sharedDirs = [];
-        $this->sharedFiles = [];
+        $sharedDirs = [];
+        $sharedFiles = [];
 
         foreach ($paths as $path) {
             $this->validatePathIsRelativeToProject($path, __METHOD__);
             if (is_dir($this->localProjectDir.DIRECTORY_SEPARATOR.$path)) {
-                $this->sharedDirs[] = rtrim($path, DIRECTORY_SEPARATOR);
+                $sharedDirs[] = rtrim($path, DIRECTORY_SEPARATOR);
             } else {
-                $this->sharedFiles[] = $path;
+                $sharedFiles[] = $path;
             }
         }
+
+        $this->sharedFiles($sharedFiles);
+        $this->sharedDirs($sharedDirs);
 
         return $this;
     }


### PR DESCRIPTION
We don't commit out .htaccess file as this may change depending on the server. For a fresh repo setup locally, the web/.htaccess file doesn't exist.

So for the config below:

```php
 ->sharedFilesAndDirs(array(
                'app/logs/',
                'app/var/',
                'web/.htaccess',
                'web/media',
            ))
```

It fails because of validatePathIsRelativeToProject can't find .htaccess and determine if .htaccess is a file or folder.

I propose we split sharedFilesAndDirs() into sharedFiles() and sharedDirs(). 