### PR TITLE
Relative path finding fix

### DIFF
--- a/src/Configuration/DefaultConfiguration.php
+++ b/src/Configuration/DefaultConfiguration.php
@@ -272,6 +272,10 @@ final class DefaultConfiguration extends AbstractConfiguration
 
         $localRelativePaths = array_map(function ($absolutePath) {
             $relativePath = str_replace($this->localProjectDir, '', $absolutePath);
+            if (Str::startsWith($absolutePath, $this->localProjectDir)) {
+                $relativePath = mb_substr($absolutePath, mb_strlen($this->localProjectDir));
+            }
+
             $this->validatePathIsRelativeToProject($relativePath, 'controllersToRemove');
 
             return trim($relativePath, DIRECTORY_SEPARATOR);


### PR DESCRIPTION
If `$this->localProjectDir = '/app'` and `$absolutePath = '/app/web/app_dev.php'` then `$relativePath = '/web_dev.php'` and `validatePathIsRelativeToProject` throws `InvalidConfigurationException`.
As I understand it should remove absolute paths dir