### PR TITLE
Update path to find config file

### DIFF
--- a/src/Helper/SymfonyConfigPathGuesser.php
+++ b/src/Helper/SymfonyConfigPathGuesser.php
@@ -17,7 +17,7 @@ namespace EasyCorp\Bundle\EasyDeployBundle\Helper;
 class SymfonyConfigPathGuesser
 {
     private const LEGACY_CONFIG_DIR = '%s/app/config';
-    private const CONFIG_DIR = '%s/etc';
+    private const CONFIG_DIR = '%s/config';
 
     public static function guess(string $projectDir, string $stage): string
     {


### PR DESCRIPTION
After the SF4 changed it's directory structure this is necessary.

See: https://medium.com/@fabpot/symfony-4-directory-structure-updates-d8f4686546d5