### PR TITLE
Fix app/logs creation for Symfony 2

### DIFF
--- a/src/Configuration/DefaultConfiguration.php
+++ b/src/Configuration/DefaultConfiguration.php
@@ -367,7 +367,7 @@ final class DefaultConfiguration extends AbstractConfiguration
             $this->setDirs('app', 'app/config', 'app/cache', 'app/logs', 'src', 'app/Resources/views', 'web');
             $this->controllersToRemove(['web/app_*.php']);
             $this->sharedFiles = ['app/config/parameters.yml'];
-            $this->sharedDirs = ['app/logs/'];
+            $this->sharedDirs = ['app/logs'];
             $this->writableDirs = ['app/cache/', 'app/logs/'];
             $this->dumpAsseticAssets = true;
         } elseif (3 === $symfonyVersion) {


### PR DESCRIPTION
Resolve the issue https://github.com/EasyCorp/easy-deploy-bundle/issues/22
Fix the err :: ln: target `/app/logs/' is not a directory: No such file or directory for Symfony 2 deployment