### PR TITLE
doUpdateCode doesn't copy dot hidden files

### DIFF
--- a/src/Deployer/DefaultDeployer.php
+++ b/src/Deployer/DefaultDeployer.php
@@ -261,7 +261,7 @@ abstract class DefaultDeployer extends AbstractDeployer
         $this->runRemote(sprintf('if [ -d {{ deploy_dir }}/repo ]; then cd {{ deploy_dir }}/repo && git fetch -q origin && git fetch --tags -q origin && git reset -q --hard %s && git clean -q -d -x -f; else git clone -q -b %s %s {{ deploy_dir }}/repo && cd {{ deploy_dir }}/repo && git checkout -q -b deploy %s; fi', $repositoryRevision, $this->getConfig(Option::repositoryBranch), $this->getConfig(Option::repositoryUrl), $repositoryRevision));
 
         $this->log('<h3>Copying the updated code to the new release directory</>');
-        $this->runRemote(sprintf('cp -RPp {{ deploy_dir }}/repo/* {{ project_dir }}'));
+        $this->runRemote(sprintf('cp -RPp {{ deploy_dir }}/repo/. {{ project_dir }}'));
     }
 
     private function doCreateCacheDir(): void


### PR DESCRIPTION
Currently in the DefaultDeployer, this line:
```cp -RPp {{ deploy_dir }}/repo/* {{ project_dir }}```

does not copy the dot files that belong to the `repo` directory (for example .babelrc in my case is not copied).

Changing it by `cp -RPp {{ deploy_dir }}/repo/. {{ project_dir }}` makes it copy all the files, including the dot files.
See reference here: https://superuser.com/questions/61611/how-to-copy-with-cp-to-include-hidden-files-and-hidden-directories-and-their-con