### PR TITLE
Fix default folder configuration for Symfony 3

### DIFF
--- a/src/Configuration/DefaultConfiguration.php
+++ b/src/Configuration/DefaultConfiguration.php
@@ -374,14 +374,14 @@ final class DefaultConfiguration extends AbstractConfiguration
             $this->sharedDirs = ['app/logs'];
             $this->writableDirs = ['app/cache/', 'app/logs/'];
             $this->dumpAsseticAssets = true;
-        } elseif (3 === $symfonyMajorVersion && 4 < $symfonyMinorVersion) {
+        } elseif (3 === $symfonyMajorVersion) {
             $this->_symfonyEnvironmentEnvVarName = 'SYMFONY_ENV';
             $this->setDirs('bin', 'app/config', 'var/cache', 'var/logs', 'src', 'app/Resources/views', 'web');
             $this->controllersToRemove(['web/app_*.php']);
             $this->sharedFiles = ['app/config/parameters.yml'];
             $this->sharedDirs = ['var/logs'];
             $this->writableDirs = ['var/cache/', 'var/logs/'];
-        } elseif (4 === $symfonyMajorVersion || (3 === $symfonyMajorVersion && 4 >= $symfonyMinorVersion)) {
+        } elseif (4 === $symfonyMajorVersion) {
             $this->_symfonyEnvironmentEnvVarName = 'APP_ENV';
             $this->setDirs('bin', 'config', 'var/cache', 'var/log', 'src', 'templates', 'public');
             $this->controllersToRemove([]);


### PR DESCRIPTION
Hi!

The deployer fails when trying to deploy a Symfony 3.4 application, as the default configuration sets the folder structure as it is a Symfony 4 application. Symfony's documentation explains the architecture for 3.4 applications: https://symfony.com/doc/3.4/quick_tour/the_architecture.html

That is specially true for applications that have been upgraded from earlier versions.

I have removed the check, but maybe the checks should be more accurate? I can try to do it, if I know how versions differ between them.

Thank you!

Regards!