### PR TITLE
Prevent reinitialize of shared files and folders arrays

### DIFF
--- a/src/Configuration/DefaultConfiguration.php
+++ b/src/Configuration/DefaultConfiguration.php
@@ -331,9 +331,6 @@ final class DefaultConfiguration extends AbstractConfiguration
     // Relative to the project root directory
     public function sharedFilesAndDirs(array $paths = []): self
     {
-        $this->sharedDirs = [];
-        $this->sharedFiles = [];
-
         foreach ($paths as $path) {
             $this->validatePathIsRelativeToProject($path, __METHOD__);
             if (is_dir($this->localProjectDir.DIRECTORY_SEPARATOR.$path)) {


### PR DESCRIPTION
Hi,

When having multiple shared folders and dirs, the arrays containing that data where reinitialized, therefore removing Symfony shared folders and files, and deploy failed.

This commit simply prevents reinitializing those arrays.

Regards.