### PR TITLE
replaced repo/* with repo/. so it will copy all files including hidden

### DIFF
--- a/src/Deployer/DefaultDeployer.php
+++ b/src/Deployer/DefaultDeployer.php
@@ -261,7 +261,7 @@ abstract class DefaultDeployer extends AbstractDeployer
         $this->runRemote(sprintf('if [ -d {{ deploy_dir }}/repo ]; then cd {{ deploy_dir }}/repo && git fetch -q origin && git fetch --tags -q origin && git reset -q --hard %s && git clean -q -d -x -f; else git clone -q -b %s %s {{ deploy_dir }}/repo && cd {{ deploy_dir }}/repo && git checkout -q -b deploy %s; fi', $repositoryRevision, $this->getConfig(Option::repositoryBranch), $this->getConfig(Option::repositoryUrl), $repositoryRevision));
 
         $this->log('<h3>Copying the updated code to the new release directory</>');
-        $this->runRemote(sprintf('cp -RPp {{ deploy_dir }}/repo/* {{ project_dir }}'));
+        $this->runRemote(sprintf('cp -RPp {{ deploy_dir }}/repo/. {{ project_dir }}'));
     }
 
     private function doCreateCacheDir(): void


### PR DESCRIPTION
I have noticed that in the DefaultDeployer.php you copy the folder with the following command.
```cp -RPp {{ deploy_dir }}/repo/* {{ project_dir }}```
But the wildcard (*) filemask skips hidden files starting with a dot (.gitignore, .env.test).
To do a full copy including hidden files you should use the dot instead of the wildcard
```cp -RPp {{ deploy_dir }}/repo/. {{ project_dir }}```
This should result in a compleet copy of the repo directory into the release directory.

In my case we use .env.test .env.prod files and we wanted to copy them to .env but the files weren't copied so i got an error.
If the wildcard is intentional to prevent security issues i can understand. But in my opinion it should copy the complete directory to prevent weird behavior.