### PR TITLE
Use remotePhpBinaryPath when run composer

### DIFF
--- a/src/Deployer/DefaultDeployer.php
+++ b/src/Deployer/DefaultDeployer.php
@@ -337,11 +337,24 @@ abstract class DefaultDeployer extends AbstractDeployer
     {
         if (true === $this->getConfig(Option::updateRemoteComposerBinary)) {
             $this->log('<h2>Self Updating the Composer binary</>');
-            $this->runRemote(sprintf('%s self-update', $this->getConfig(Option::remoteComposerBinaryPath)));
+            $this->runRemote(
+                sprintf(
+                    '%s %s self-update',
+                    $this->getConfig(Option::remotePhpBinaryPath),
+                    $this->getConfig(Option::remoteComposerBinaryPath)
+                )
+            );
         }
 
         $this->log('<h2>Installing Composer dependencies</>');
-        $this->runRemote(sprintf('%s install %s', $this->getConfig(Option::remoteComposerBinaryPath), $this->getConfig(Option::composerInstallFlags)));
+        $this->runRemote(
+            sprintf(
+                '%s %s install %s',
+                $this->getConfig(Option::remotePhpBinaryPath),
+                $this->getConfig(Option::remoteComposerBinaryPath),
+                $this->getConfig(Option::composerInstallFlags)
+            )
+        );
     }
 
     private function doInstallWebAssets(): void
@@ -390,7 +403,14 @@ abstract class DefaultDeployer extends AbstractDeployer
     private function doOptimizeComposer(): void
     {
         $this->log('<h2>Optimizing Composer autoloader</>');
-        $this->runRemote(sprintf('%s dump-autoload %s', $this->getConfig(Option::remoteComposerBinaryPath), $this->getConfig(Option::composerOptimizeFlags)));
+        $this->runRemote(
+            sprintf(
+                '%s %s dump-autoload %s',
+                $this->getConfig(Option::remotePhpBinaryPath),
+                $this->getConfig(Option::remoteComposerBinaryPath),
+                $this->getConfig(Option::composerOptimizeFlags)
+            )
+        );
     }
 
     private function doCreateSymlink(): void


### PR DESCRIPTION
On some shared hostings, we have to use the specified path for PHP binary because of just `php` can be an outdated version.
For example:
```
-bash-4.1$ which php
/usr/bin/php
-bash-4.1$ php -v
PHP 7.0.21 (cli) (built: Aug 21 2017 17:45:33) ( NTS )
-bash-4.1$ /opt/php71f/bin/php -v 
PHP 7.1.19 (cli) (built: Jul  4 2018 10:51:26) ( NTS )
```
If composer.json requires php 7.1+, then function `doInstallDependencies` will fail because of composer check interpeter version.
`doInstallDependencies` generates the command:
```
/storage/home/srv115367/admin.dom-nf.ru/composer.phar install --no-dev --prefer-dist --no-interaction --quiet
```
`composer install` command is executed without specified php interpeter:
```
Executing command: (export APP_ENV=prod; cd /storage/home/user/project/releases/20190418164853 && /storage/home/user/project/composer.phar install --no-dev --prefer-dist --no-interaction --quiet)
```
So `composer install` will fail in this case with the error like:
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - This package requires php ^7.1.3 but your HHVM version does not satisfy that requirement.
  Problem 2
    - Installation request for doctrine/annotations v1.6.0 -> satisfiable by doctrine/annotations[v1.6.0].
    - doctrine/annotations v1.6.0 requires php ^7.1 -> your PHP version (7.0.21) does not satisfy that requirement.
```

In this PR I suggest running `composer` with specified `remotePhpBinaryPath`.

ref #90 