### PR TITLE
Fixes: Unable to read the `.env` environment file

### DIFF
--- a/src/Deployer/DefaultDeployer.php
+++ b/src/Deployer/DefaultDeployer.php
@@ -261,7 +261,7 @@ abstract class DefaultDeployer extends AbstractDeployer
         $this->runRemote(sprintf('if [ -d {{ deploy_dir }}/repo ]; then cd {{ deploy_dir }}/repo && git fetch -q origin && git fetch --tags -q origin && git reset -q --hard %s && git clean -q -d -x -f; else git clone -q -b %s %s {{ deploy_dir }}/repo && cd {{ deploy_dir }}/repo && git checkout -q -b deploy %s; fi', $repositoryRevision, $this->getConfig(Option::repositoryBranch), $this->getConfig(Option::repositoryUrl), $repositoryRevision));
 
         $this->log('<h3>Copying the updated code to the new release directory</>');
-        $this->runRemote(sprintf('cp -pPRT {{ deploy_dir }}/repo/* {{ project_dir }}'));
+        $this->runRemote(sprintf('cp -pPRT {{ deploy_dir }}/repo/ {{ project_dir }}'));
     }
 
     private function doCreateCacheDir(): void

--- a/src/Deployer/DefaultDeployer.php
+++ b/src/Deployer/DefaultDeployer.php
@@ -261,7 +261,7 @@ abstract class DefaultDeployer extends AbstractDeployer
         $this->runRemote(sprintf('if [ -d {{ deploy_dir }}/repo ]; then cd {{ deploy_dir }}/repo && git fetch -q origin && git fetch --tags -q origin && git reset -q --hard %s && git clean -q -d -x -f; else git clone -q -b %s %s {{ deploy_dir }}/repo && cd {{ deploy_dir }}/repo && git checkout -q -b deploy %s; fi', $repositoryRevision, $this->getConfig(Option::repositoryBranch), $this->getConfig(Option::repositoryUrl), $repositoryRevision));
 
         $this->log('<h3>Copying the updated code to the new release directory</>');
-        $this->runRemote(sprintf('cp -RPp {{ deploy_dir }}/repo/* {{ project_dir }}'));
+        $this->runRemote(sprintf('cp -pPRT {{ deploy_dir }}/repo/* {{ project_dir }}'));
     }
 
     private function doCreateCacheDir(): void


### PR DESCRIPTION
This fixes issues like https://github.com/EasyCorp/easy-deploy-bundle/issues/87
```
Unable to read the "... .env" environment file. in ...
```
Tested on Symfony 5 with PHP 7.4