### PR TITLE
feat: allow Symfony6 + phpunit upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor/*
+.phpunit.result.cache
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -13,17 +13,17 @@
     ],
     "require": {
         "php": ">=7.2.0",
-        "symfony/console": "~2.3|~3.0|~4.0|~5.0",
-        "symfony/dependency-injection": "~2.3|~3.0|~4.0|~5.0",
-        "symfony/expression-language": "~2.4|~3.0|~4.0|~5.0",
-        "symfony/filesystem": "~2.3|~3.0|~4.0|~5.0",
-        "symfony/http-foundation": "~2.3|~3.0|~4.0|~5.0",
-        "symfony/http-kernel": "~2.3|~3.0|~4.0|~5.0",
+        "symfony/console": "~2.3|~3.0|~4.0|~5.0|~6.0",
+        "symfony/dependency-injection": "~2.3|~3.0|~4.0|~5.0|~6.0",
+        "symfony/expression-language": "~2.4|~3.0|~4.0|~5.0|~6.0",
+        "symfony/filesystem": "~2.3|~3.0|~4.0|~5.0|~6.0",
+        "symfony/http-foundation": "~2.3|~3.0|~4.0|~5.0|~6.0",
+        "symfony/http-kernel": "~2.3|~3.0|~4.0|~5.0|~6.0",
         "symfony/polyfill-mbstring": "^1.3",
-        "symfony/process": "~2.3|~3.0|~4.0|~5.0"
+        "symfony/process": "~2.3|~3.0|~4.0|~5.0|~6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.1"
+        "phpunit/phpunit": "^9.5"
     },
     "config": {
         "sort-packages": true

--- a/tests/Configuration/ConfigurationAdapterTest.php
+++ b/tests/Configuration/ConfigurationAdapterTest.php
@@ -21,7 +21,7 @@ class ConfigurationAdapterTest extends TestCase
     /** @var DefaultConfiguration */
     private $config;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->config = (new DefaultConfiguration(__DIR__))
             ->sharedFilesAndDirs([])
@@ -32,7 +32,7 @@ class ConfigurationAdapterTest extends TestCase
         ;
     }
 
-    public function test_get_options()
+    public function test_get_options(): void
     {
         $config = new ConfigurationAdapter($this->config);
 

--- a/tests/Configuration/DefaultConfigurationTest.php
+++ b/tests/Configuration/DefaultConfigurationTest.php
@@ -12,34 +12,36 @@
 namespace EasyCorp\Bundle\EasyDeployBundle\Tests;
 
 use EasyCorp\Bundle\EasyDeployBundle\Configuration\DefaultConfiguration;
+use EasyCorp\Bundle\EasyDeployBundle\Exception\InvalidConfigurationException;
 use PHPUnit\Framework\TestCase;
 
 class DefaultConfigurationTest extends TestCase
 {
     /**
      * @dataProvider provideHttpRepositoryUrls
-     * @expectedException \EasyCorp\Bundle\EasyDeployBundle\Exception\InvalidConfigurationException
-     * @expectedExceptionMessageRegExp /The repository URL must use the SSH syntax instead of the HTTPs syntax to make it work on any remote server. Replace "https?:\/\/.*\/symfony\/symfony-demo.git" by "git@.*:symfony\/symfony-demo.git"/
      */
-    public function test_repository_url_protocol(string $url)
+    public function test_repository_url_protocol(string $url): void
     {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessageMatches('/The repository URL must use the SSH syntax instead of the HTTPs syntax to make it work on any remote server. Replace "https?:\/\/.*\/symfony\/symfony-demo.git" by "git@.*:symfony\/symfony-demo.git"/');
+
         (new DefaultConfiguration(__DIR__))
             ->repositoryUrl($url)
         ;
     }
 
-    /**
-     * @expectedException \EasyCorp\Bundle\EasyDeployBundle\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The value of resetOpCacheFor option must be the valid URL of your homepage (it must start with http:// or https://).
-     */
-    public function test_reset_opcache_for()
+    public function test_reset_opcache_for(): void
     {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The value of resetOpCacheFor option must be the valid URL of your homepage (it must start with http:// or https://).');
+
+
         (new DefaultConfiguration(__DIR__))
             ->resetOpCacheFor('symfony.com')
         ;
     }
 
-    public function provideHttpRepositoryUrls()
+    public function provideHttpRepositoryUrls(): ?\Generator
     {
         yield ['http://github.com/symfony/symfony-demo.git'];
         yield ['https://github.com/symfony/symfony-demo.git'];

--- a/tests/Helper/StrTest.php
+++ b/tests/Helper/StrTest.php
@@ -17,36 +17,36 @@ use PHPUnit\Framework\TestCase;
 class StrTest extends TestCase
 {
     /** @dataProvider startsWithProvider */
-    public function test_starts_with(string $haystack, string $needle, bool $expectedResult)
+    public function test_starts_with(string $haystack, string $needle, bool $expectedResult): void
     {
         $this->assertSame($expectedResult, Str::startsWith($haystack, $needle));
     }
 
     /** @dataProvider endsWithProvider */
-    public function test_ends_with(string $haystack, string $needle, bool $expectedResult)
+    public function test_ends_with(string $haystack, string $needle, bool $expectedResult): void
     {
         $this->assertSame($expectedResult, Str::endsWith($haystack, $needle));
     }
 
     /** @dataProvider containsProvider */
-    public function test_contains(string $haystack, string $needle, bool $expectedResult)
+    public function test_contains(string $haystack, string $needle, bool $expectedResult): void
     {
         $this->assertSame($expectedResult, Str::contains($haystack, $needle));
     }
 
     /** @dataProvider prefixProvider */
-    public function test_prefix($text, string $prefix, string $expectedResult)
+    public function test_prefix($text, string $prefix, string $expectedResult): void
     {
         $this->assertSame($expectedResult, Str::prefix($text, $prefix));
     }
 
     /** @dataProvider stringifyProvider */
-    public function test_stringify($value, string $expectedResult)
+    public function test_stringify($value, string $expectedResult): void
     {
         $this->assertSame($expectedResult, Str::stringify($value));
     }
 
-    public function test_format_as_table()
+    public function test_format_as_table(): void
     {
         $values = ['key1' => -3.14, 'key3 with long name' => ['a', 'b' => 2], 'key2' => 'aaa'];
         $result = <<<TABLE
@@ -58,7 +58,7 @@ TABLE;
         $this->assertSame($result, Str::formatAsTable($values));
     }
 
-    public function startsWithProvider()
+    public function startsWithProvider(): ?\Generator
     {
         yield ['', '', false];
         yield ['abc', '', false];
@@ -71,7 +71,7 @@ TABLE;
         yield ['<h1>a</> bc', 'a', false];
     }
 
-    public function endsWithProvider()
+    public function endsWithProvider(): ?\Generator
     {
         yield ['', '', true];
         yield ['abc', '', false];
@@ -84,7 +84,7 @@ TABLE;
         yield ['ab <h1>c</>', 'c', false];
     }
 
-    public function containsProvider()
+    public function containsProvider(): ?\Generator
     {
         yield ['', '', false];
         yield ['abc', '', false];
@@ -102,7 +102,7 @@ TABLE;
         yield ['ab <h1>c</>', 'ab c', false];
     }
 
-    public function prefixProvider()
+    public function prefixProvider(): ?\Generator
     {
         yield ['', '', ''];
         yield ['aaa', 'xxx', 'xxxaaa'];
@@ -110,7 +110,7 @@ TABLE;
         yield [['aaa', 'bbb', 'ccc'], 'xxx', "xxxaaa\nxxxbbb\nxxxccc"];
     }
 
-    public function stringifyProvider()
+    public function stringifyProvider(): ?\Generator
     {
         yield ['', ''];
         yield [fopen('php://memory', 'r+'), 'PHP Resource'];

--- a/tests/Server/ServerRepositoryTest.php
+++ b/tests/Server/ServerRepositoryTest.php
@@ -20,7 +20,7 @@ class ServerRepositoryTest extends TestCase
     /** @var ServerRepository */
     private $servers;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $repository = new ServerRepository();
         $repository->add(new Server('host0'));

--- a/tests/Server/ServerTest.php
+++ b/tests/Server/ServerTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 class ServerTest extends TestCase
 {
     /** @dataProvider dsnProvider */
-    public function test_dsn_parsing(string $dsn, string $expectedHost, ?string $expectedUser, ?int $expectedPort)
+    public function test_dsn_parsing(string $dsn, string $expectedHost, ?string $expectedUser, ?int $expectedPort): void
     {
         $server = new Server($dsn);
 
@@ -27,17 +27,16 @@ class ServerTest extends TestCase
         $this->assertSame($expectedPort, $server->getPort());
     }
 
-    /**
-     * @expectedException \EasyCorp\Bundle\EasyDeployBundle\Exception\ServerConfigurationException
-     * @expectedExceptionMessage The host is missing (define it as an IP address or a host name)
-     */
-    public function test_dsn_parsing_error()
+    public function test_dsn_parsing_error(): void
     {
+        $this->expectException(\EasyCorp\Bundle\EasyDeployBundle\Exception\ServerConfigurationException::class);
+        $this->expectExceptionMessage('The host is missing (define it as an IP address or a host name)');
+
         new Server('deployer@');
     }
 
     /** @dataProvider localDsnProvider */
-    public function test_local_dsn_parsing(string $dsn)
+    public function test_local_dsn_parsing(string $dsn): void
     {
         $server = new Server($dsn);
 
@@ -45,14 +44,14 @@ class ServerTest extends TestCase
     }
 
     /** @dataProvider sshConnectionStringProvider */
-    public function test_ssh_connection_string($dsn, $expectedSshConnectionString)
+    public function test_ssh_connection_string($dsn, $expectedSshConnectionString): void
     {
         $server = new Server($dsn);
 
         $this->assertSame($expectedSshConnectionString, $server->getSshConnectionString());
     }
 
-    public function test_ssh_agent_forwarding()
+    public function test_ssh_agent_forwarding(): void
     {
         $server = new Server('host');
         $server->set(Property::use_ssh_agent_forwarding, true);
@@ -60,7 +59,7 @@ class ServerTest extends TestCase
         $this->assertSame('ssh -A host', $server->getSshConnectionString());
     }
 
-    public function test_default_server_roles()
+    public function test_default_server_roles(): void
     {
         $server = new Server('host');
 
@@ -68,21 +67,21 @@ class ServerTest extends TestCase
     }
 
     /** @dataProvider serverRolesProvider */
-    public function test_server_roles(array $definedRoles, array $expectedRoles)
+    public function test_server_roles(array $definedRoles, array $expectedRoles): void
     {
         $server = new Server('host', $definedRoles);
 
         $this->assertSame($expectedRoles, $server->getRoles());
     }
 
-    public function test_default_server_properties()
+    public function test_default_server_properties(): void
     {
         $server = new Server('host');
 
         $this->assertSame([], $server->getProperties());
     }
 
-    public function test_server_properties()
+    public function test_server_properties(): void
     {
         $properties = ['prop1' => -3.14, 'prop2' => false, 'prop3' => 'Lorem Ipsum', 'prop4' => ['foo' => 'bar']];
         $server = new Server('host', [], $properties);
@@ -90,7 +89,7 @@ class ServerTest extends TestCase
         $this->assertSame($properties, $server->getProperties());
     }
 
-    public function test_get_set_has_server_properties()
+    public function test_get_set_has_server_properties(): void
     {
         $properties = ['prop1' => -3.14, 'prop2' => false, 'prop3' => 'Lorem Ipsum', 'prop4' => ['foo' => 'bar']];
         $server = new Server('host');
@@ -106,7 +105,7 @@ class ServerTest extends TestCase
     }
 
     /** @dataProvider expressionProvider */
-    public function test_resolve_properties(array $properties, string $expression, string $expectedExpression)
+    public function test_resolve_properties(array $properties, string $expression, string $expectedExpression): void
     {
         $server = new Server('host', [], $properties);
 
@@ -115,16 +114,16 @@ class ServerTest extends TestCase
 
     /**
      * @dataProvider wrongExpressionProvider
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The ".*" property in ".*" expression is not a valid server property./
      */
-    public function test_resolve_unknown_properties(array $properties, string $expression)
+    public function test_resolve_unknown_properties(array $properties, string $expression): void
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/The ".*" property in ".*" expression is not a valid server property./');
         $server = new Server('host', [], $properties);
         $server->resolveProperties($expression);
     }
 
-    public function dsnProvider()
+    public function dsnProvider(): ?\Generator
     {
         yield ['123.123.123.123', '123.123.123.123', null, null];
         yield ['deployer@123.123.123.123', '123.123.123.123', 'deployer', null];
@@ -143,7 +142,7 @@ class ServerTest extends TestCase
         yield ['ssh://deployer@host:22001', 'host', 'deployer', 22001];
     }
 
-    public function localDsnProvider()
+    public function localDsnProvider(): ?\Generator
     {
         yield ['local'];
         yield ['deployer@local'];
@@ -158,7 +157,7 @@ class ServerTest extends TestCase
         yield ['deployer@127.0.0.1:22001'];
     }
 
-    public function serverRolesProvider()
+    public function serverRolesProvider(): ?\Generator
     {
         yield [[], []];
         yield [[Server::ROLE_APP], [Server::ROLE_APP]];
@@ -166,7 +165,7 @@ class ServerTest extends TestCase
         yield [['custom_role_1', 'custom_role_2'], ['custom_role_1', 'custom_role_2']];
     }
 
-    public function sshConnectionStringProvider()
+    public function sshConnectionStringProvider(): ?\Generator
     {
         yield ['localhost', ''];
         yield ['123.123.123.123', 'ssh 123.123.123.123'];
@@ -174,7 +173,7 @@ class ServerTest extends TestCase
         yield ['deployer@123.123.123.123:22001', 'ssh deployer@123.123.123.123 -p 22001'];
     }
 
-    public function expressionProvider()
+    public function expressionProvider(): ?\Generator
     {
         yield [['prop1' => 'aaa'], '{{ prop1 }}', 'aaa'];
         yield [['prop.1' => 'aaa'], '{{ prop.1 }}', 'aaa'];
@@ -188,7 +187,7 @@ class ServerTest extends TestCase
         yield [['prop1' => 'aaa', 'prop2' => 'bbb'], 'cd {{ prop1 }}{{ prop2 }}', 'cd aaabbb'];
     }
 
-    public function wrongExpressionProvider()
+    public function wrongExpressionProvider(): ?\Generator
     {
         yield [[], '{{ prop1 }}'];
         yield [['prop1' => 'aaa'], '{{ prop 1 }}'];

--- a/tests/Task/TaskCompletedTest.php
+++ b/tests/Task/TaskCompletedTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 class TaskCompletedTest extends TestCase
 {
-    public function test_server()
+    public function test_server(): void
     {
         $result = new TaskCompleted(new Server('deployer@host1'), 'aaa', 0);
 
@@ -25,7 +25,7 @@ class TaskCompletedTest extends TestCase
         $this->assertSame('host1', $result->getServer()->getHost());
     }
 
-    public function test_output()
+    public function test_output(): void
     {
         $result = new TaskCompleted(new Server('localhost'), 'aaa   ', 0);
 
@@ -33,7 +33,7 @@ class TaskCompletedTest extends TestCase
         $this->assertSame('aaa', $result->getTrimmedOutput());
     }
 
-    public function test_exit_code()
+    public function test_exit_code(): void
     {
         $result = new TaskCompleted(new Server('localhost'), 'aaa', -1);
 


### PR DESCRIPTION
This PR allows using this bundle with Symfony6. Until it is merged, you can use the fork:

    "repositories": {
        "strangebuzz/easy-deploy-bundle": {
            "type": "vcs",
            "url": "git@github.com:strangebuzz/easy-deploy-bundle.git"
        }
    },
